### PR TITLE
Move to TrueCharts for helm charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Use your own server
     - Add torrent client
       - Go to ``Settings > Download Clients > Add > qBittorent > Custom``
       - Add the host: ``qbittorrent``
-      - Add the port: ``8080``
+      - Add the port: ``10095``
       - Add the username: ``<qBittorrent_username>``
       - Add the password: ``<qBittorrent_password>``
       - Uncheck the ``Remove Completed`` option.

--- a/README.md
+++ b/README.md
@@ -257,8 +257,8 @@ Use your own server
           ```
           Nyaa.si
           ```
-    - Add Sonarr, Radarr and Readarr to the ``Settings > Apps > Application`` section using the correct API token and kubernetes service names
-      - By default the services will be ``http://sonarr:8989``, ``http://radarr:7878`` and ``http://readarr:8787``
+    - Add Sonarr, Radarr, Lidarr and Readarr to the ``Settings > Apps > Application`` section using the correct API token and kubernetes service names
+      - By default the services will be ``http://sonarr:8989``, ``http://radarr:7878``, ``http://lidarr:8686`` and ``http://readarr:8787``
 
   - ##### Setup Bazarr
     - Enable authentication

--- a/group_vars/all
+++ b/group_vars/all
@@ -42,6 +42,16 @@ bluetooth:
 # ==== Select what services you wish to install ====
 charts:
   enabled: True
+  resources:
+    # kubernetes resource requests for all the pods
+    requests:
+      cpu: 0
+      memory: 0
+    # kubernetes resource limits for all the pods
+    # probably should match these with the minikube resources from below
+    limits:
+      cpu: 4
+      memory: "6000M"
   # timeout as helm expects it in --timeout for the charts
   timeout: 15m
   services:

--- a/install-charts.yaml
+++ b/install-charts.yaml
@@ -139,8 +139,9 @@
           timeout: "{{ charts.timeout }}"
           release_name: jellyfin
           chart_name: jellyfin
-          # to allow the pod # to be able to use the /dev mount
+          # to allow the pod to be able to use the /dev mount
           # to access /dev/dri/renderD128 for hwa, these options are set to true
+          # - common.podSecurityContext.runAsUser=0
           # - common.securityContext.privileged=true
           # - common.securityContext.allowPrivilegeEscalation=true
           set_options: "--set \
@@ -150,6 +151,7 @@
             {{ helm_common_persistence_media }},\
             {{ helm_common_resources }},\
             {{ helm_common_ingress }},\
+            common.podSecurityContext.runAsUser=0,\
             common.securityContext.privileged=true,\
             common.securityContext.allowPrivilegeEscalation=true,\
             persistence.cache.enabled=true,\

--- a/install-charts.yaml
+++ b/install-charts.yaml
@@ -139,6 +139,10 @@
             persistence.dev.type=hostPath,\
             persistence.dev.mountPath=/dev,\
             persistence.dev.hostPath=/dev,\
+            resources.requests.cpu={{ charts.resources.requests.cpu }},\
+            resources.requests.memory={{ charts.resources.requests.memory }},\
+            resources.limits.cpu={{ charts.resources.limits.cpu }},\
+            resources.limits.memory={{ charts.resources.limits.memory }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
@@ -195,6 +199,10 @@
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
+            resources.requests.cpu={{ charts.resources.requests.cpu }},\
+            resources.requests.memory={{ charts.resources.requests.memory }},\
+            resources.limits.cpu={{ charts.resources.limits.cpu }},\
+            resources.limits.memory={{ charts.resources.limits.memory }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
@@ -252,6 +260,10 @@
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
+            resources.requests.cpu={{ charts.resources.requests.cpu }},\
+            resources.requests.memory={{ charts.resources.requests.memory }},\
+            resources.limits.cpu={{ charts.resources.limits.cpu }},\
+            resources.limits.memory={{ charts.resources.limits.memory }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
@@ -309,6 +321,10 @@
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
+            resources.requests.cpu={{ charts.resources.requests.cpu }},\
+            resources.requests.memory={{ charts.resources.requests.memory }},\
+            resources.limits.cpu={{ charts.resources.limits.cpu }},\
+            resources.limits.memory={{ charts.resources.limits.memory }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
@@ -365,6 +381,10 @@
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
+            resources.requests.cpu={{ charts.resources.requests.cpu }},\
+            resources.requests.memory={{ charts.resources.requests.memory }},\
+            resources.limits.cpu={{ charts.resources.limits.cpu }},\
+            resources.limits.memory={{ charts.resources.limits.memory }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
@@ -421,6 +441,10 @@
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
+            resources.requests.cpu={{ charts.resources.requests.cpu }},\
+            resources.requests.memory={{ charts.resources.requests.memory }},\
+            resources.limits.cpu={{ charts.resources.limits.cpu }},\
+            resources.limits.memory={{ charts.resources.limits.memory }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
@@ -476,6 +500,10 @@
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
+            resources.requests.cpu={{ charts.resources.requests.cpu }},\
+            resources.requests.memory={{ charts.resources.requests.memory }},\
+            resources.limits.cpu={{ charts.resources.limits.cpu }},\
+            resources.limits.memory={{ charts.resources.limits.memory }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
@@ -531,6 +559,10 @@
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
+            resources.requests.cpu={{ charts.resources.requests.cpu }},\
+            resources.requests.memory={{ charts.resources.requests.memory }},\
+            resources.limits.cpu={{ charts.resources.limits.cpu }},\
+            resources.limits.memory={{ charts.resources.limits.memory }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
@@ -580,6 +612,10 @@
             common.podSecurityContext.fsGroup=568,\
             persistence.config.enabled=true,\
             persistence.config.size=1Gi,\
+            resources.requests.cpu={{ charts.resources.requests.cpu }},\
+            resources.requests.memory={{ charts.resources.requests.memory }},\
+            resources.limits.cpu={{ charts.resources.limits.cpu }},\
+            resources.limits.memory={{ charts.resources.limits.memory }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
@@ -630,6 +666,10 @@
             common.podSecurityContext.fsGroup=568,\
             persistence.config.enabled=true,\
             persistence.config.size=1Gi,\
+            resources.requests.cpu={{ charts.resources.requests.cpu }},\
+            resources.requests.memory={{ charts.resources.requests.memory }},\
+            resources.limits.cpu={{ charts.resources.limits.cpu }},\
+            resources.limits.memory={{ charts.resources.limits.memory }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
@@ -683,6 +723,10 @@
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
+            resources.requests.cpu={{ charts.resources.requests.cpu }},\
+            resources.requests.memory={{ charts.resources.requests.memory }},\
+            resources.limits.cpu={{ charts.resources.limits.cpu }},\
+            resources.limits.memory={{ charts.resources.limits.memory }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
@@ -738,6 +782,10 @@
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
+            resources.requests.cpu={{ charts.resources.requests.cpu }},\
+            resources.requests.memory={{ charts.resources.requests.memory }},\
+            resources.limits.cpu={{ charts.resources.limits.cpu }},\
+            resources.limits.memory={{ charts.resources.limits.memory }},\
             service.webserver.enabled=true"
 
       - name: Expose calibre service

--- a/install-charts.yaml
+++ b/install-charts.yaml
@@ -122,6 +122,10 @@
             common.manifests.enabled=false,\
             common.securityContext.privileged=true,\
             common.securityContext.allowPrivilegeEscalation=true,\
+            common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
+            common.podSecurityContext.runAsUser={{ uid }},\
+            common.podSecurityContext.runAsGroup=568,\
+            common.podSecurityContext.fsGroup=568,\
             persistence.config.enabled=true,\
             persistence.config.size=1Gi,\
             persistence.cache.enabled=true,\
@@ -570,6 +574,10 @@
             common.persistence.temp.enabled=false,\
             common.persistence.varlogs.enabled=false,\
             common.manifests.enabled=false,\
+            common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
+            common.podSecurityContext.runAsUser={{ uid }},\
+            common.podSecurityContext.runAsGroup=568,\
+            common.podSecurityContext.fsGroup=568,\
             persistence.config.enabled=true,\
             persistence.config.size=1Gi,\
             ingress.main.enabled=true,\
@@ -617,6 +625,9 @@
             common.persistence.varlogs.enabled=false,\
             common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
+            env.PUID=\"{{ uid }}\",\
+            env.PGID=\"568\",\
+            common.podSecurityContext.fsGroup=568,\
             persistence.config.enabled=true,\
             persistence.config.size=1Gi,\
             ingress.main.enabled=true,\
@@ -665,6 +676,7 @@
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             env.PUID=\"{{ uid }}\",\
             env.PGID=\"568\",\
+            podSecurityContext.fsGroup=568,\
             persistence.config.enabled=true,\
             persistence.config.size=1Gi,\
             persistence.media.enabled=true,\
@@ -719,6 +731,7 @@
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             env.PUID=\"{{ uid }}\",\
             env.PGID=\"568\",\
+            podSecurityContext.fsGroup=568,\
             persistence.config.enabled=true,\
             persistence.config.size=1Gi,\
             persistence.media.enabled=true,\

--- a/install-charts.yaml
+++ b/install-charts.yaml
@@ -7,8 +7,49 @@
     namespace_monitoring: monitoring
     namespace_generic_services: generic-services
     default_grafana_admin_password: "{{ ansible_user }}"
+    
+    # The following has been set to disable Truecharts own injection
+    # of manifests for SCALE products I believe either way I dont need it:
+    # - common.manifests.enabled=false
+    helm_common_general: "controller.type=statefulset,\
+      global.addMetalLBAnnotations=false,\
+      global.addTraefikAnnotations=false,\
+      common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
+      common.manifests.enabled=false"
+    
+    helm_common_ingress: "ingress.main.enabled=true,\
+      ingress.main.primary=false,\
+      ingress.main.ingressClassName=nginx,\
+      ingress.main.fixedMiddlewares={},\
+      ingress.main.enableFixedMiddlewares=false,\
+      ingress.main.hosts[0].paths[0].path='/',\
+      ingress.main.hosts[0].paths[0].pathType='Prefix'"
+    
+    helm_common_resources: "resources.requests.cpu={{ charts.resources.requests.cpu }},\
+      resources.requests.memory={{ charts.resources.requests.memory }},\
+      resources.limits.cpu={{ charts.resources.limits.cpu }},\
+      resources.limits.memory={{ charts.resources.limits.memory }}"
+
+    helm_common_persistence: "common.persistence.shared.enabled=false,\
+      common.persistence.shm.enabled=false,\
+      common.persistence.temp.enabled=false,\
+      common.persistence.varlogs.enabled=false,\
+      persistence.config.enabled=true,\
+      persistence.config.size=1Gi"
+
+    helm_common_persistence_media: "persistence.media.enabled=true,\
+      persistence.media.type=hostPath,\
+      persistence.media.mountPath={{ dir_mount_path }},\
+      persistence.media.hostPath={{ dir_minikube_mount }}"
+
+    # runAsUser={{ uid }} gives write access on the pod
+    # 568 is the default user ID, added to the groups cause why not
+    # fsgroup is not supported for hostpaths, but it is still present here
+    helm_common_pod_security_context: "common.podSecurityContext.runAsUser={{ uid }},\
+      common.podSecurityContext.runAsGroup=568,\
+      common.podSecurityContext.fsGroup=568"
+
   tasks:
-    # NOTE: fsgroup is not supported for hostpaths, but it is still present here
     - name: Create namespaces namespace
       shell: "kubectl create namespace {{ item }} --dry-run=client -o yaml | kubectl apply -f -"
       with_items:
@@ -56,10 +97,6 @@
           timeout: "{{ charts.timeout }}"
           release_name: kube-prometheus-stack
           chart_name: kube-prometheus-stack
-          # The following has been set to disable Truecharts own injection
-          # of manifests for SCALE products I believe
-          # either way I dont need it:
-          # - common.manifests.enabled=false
           set_options: "--set \
             prometheus.prometheusSpec.retention=730d,\
             grafana.persistence.enabled=true,\
@@ -91,7 +128,6 @@
             admin/{{ default_grafana_admin_password }}"
 
     - name: Install jellyfin
-      # https://artifacthub.io/packages/helm/k8s-at-home/jellyfin
       when: charts.services.jellyfin
       block:
       - name: Install/Upgrade the jellyfin chart
@@ -107,50 +143,23 @@
           # to access /dev/dri/renderD128 for hwa, these options are set to true
           # - common.securityContext.privileged=true
           # - common.securityContext.allowPrivilegeEscalation=true
-          # The following has been set to disable Truecharts own injection
-          # of manifests for SCALE products I believe
-          # either way I dont need it:
-          # - common.manifests.enabled=false
           set_options: "--set \
-            global.addMetalLBAnnotations=false,\
-            global.addTraefikAnnotations=false,\
-            controller.type=statefulset,\
-            common.persistence.shared.enabled=false,\
-            common.persistence.shm.enabled=false,\
-            common.persistence.temp.enabled=false,\
-            common.persistence.varlogs.enabled=false,\
-            common.manifests.enabled=false,\
+            {{ helm_common_general }},\
+            {{ helm_common_persistence }},\
+            {{ helm_common_pod_security_context }},\
+            {{ helm_common_persistence_media }},\
+            {{ helm_common_resources }},\
+            {{ helm_common_ingress }},\
             common.securityContext.privileged=true,\
             common.securityContext.allowPrivilegeEscalation=true,\
-            common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
-            common.podSecurityContext.runAsUser={{ uid }},\
-            common.podSecurityContext.runAsGroup=568,\
-            common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=true,\
-            persistence.config.size=1Gi,\
             persistence.cache.enabled=true,\
             persistence.cache.accessMode=ReadWriteOnce,\
             persistence.cache.size=50G,\
-            persistence.media.enabled=true,\
-            persistence.media.type=hostPath,\
-            persistence.media.mountPath={{ dir_mount_path }},\
-            persistence.media.hostPath={{ dir_minikube_mount }},\
             persistence.dev.enabled=true,\
             persistence.dev.type=hostPath,\
             persistence.dev.mountPath=/dev,\
             persistence.dev.hostPath=/dev,\
-            resources.requests.cpu={{ charts.resources.requests.cpu }},\
-            resources.requests.memory={{ charts.resources.requests.memory }},\
-            resources.limits.cpu={{ charts.resources.limits.cpu }},\
-            resources.limits.memory={{ charts.resources.limits.memory }},\
-            ingress.main.enabled=true,\
-            ingress.main.primary=false,\
-            ingress.main.ingressClassName=nginx,\
-            ingress.main.fixedMiddlewares={},\
-            ingress.main.enableFixedMiddlewares=false,\
             ingress.main.hosts[0].host='jellyfin.{{ domain_name }}',\
-            ingress.main.hosts[0].paths[0].path='/',\
-            ingress.main.hosts[0].paths[0].pathType='Prefix',\
             ingress.main.hosts[0].paths[0].service.name=jellyfin,\
             ingress.main.hosts[0].paths[0].service.port=8096"
 
@@ -166,7 +175,6 @@
       block:
       - name: Install/Upgrade the qbittorrent chart
         include_tasks: tasks-install-chart.yaml
-        # https://artifacthub.io/packages/helm/k8s-at-home/qbittorrent
         vars:
           repo_name: TrueCharts
           repo_link: https://charts.truecharts.org
@@ -174,43 +182,14 @@
           timeout: "{{ charts.timeout }}"
           release_name: qbittorrent
           chart_name: qbittorrent
-          # runAsUser={{ uid }} gives write access on the pod
-          # 568 is the default user ID, added to the groups cause why not
-          # The following has been set to disable Truecharts own injection
-          # of manifests for SCALE products I believe
-          # either way I dont need it:
-          # - common.manifests.enabled=false
           set_options: "--set \
-            global.addMetalLBAnnotations=false,\
-            global.addTraefikAnnotations=false,\
-            controller.type=statefulset,\
-            common.persistence.shared.enabled=false,\
-            common.persistence.shm.enabled=false,\
-            common.persistence.temp.enabled=false,\
-            common.persistence.varlogs.enabled=false,\
-            common.manifests.enabled=false,\
-            common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
-            common.podSecurityContext.runAsUser={{ uid }},\
-            common.podSecurityContext.runAsGroup=568,\
-            common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=true,\
-            persistence.config.size=1Gi,\
-            persistence.media.enabled=true,\
-            persistence.media.type=hostPath,\
-            persistence.media.mountPath={{ dir_mount_path }},\
-            persistence.media.hostPath={{ dir_minikube_mount }},\
-            resources.requests.cpu={{ charts.resources.requests.cpu }},\
-            resources.requests.memory={{ charts.resources.requests.memory }},\
-            resources.limits.cpu={{ charts.resources.limits.cpu }},\
-            resources.limits.memory={{ charts.resources.limits.memory }},\
-            ingress.main.enabled=true,\
-            ingress.main.primary=false,\
-            ingress.main.ingressClassName=nginx,\
-            ingress.main.fixedMiddlewares={},\
-            ingress.main.enableFixedMiddlewares=false,\
+            {{ helm_common_general }},\
+            {{ helm_common_persistence }},\
+            {{ helm_common_pod_security_context }},\
+            {{ helm_common_persistence_media }},\
+            {{ helm_common_resources }},\
+            {{ helm_common_ingress }},\
             ingress.main.hosts[0].host='qbittorrent.{{ domain_name }}',\
-            ingress.main.hosts[0].paths[0].path='/',\
-            ingress.main.hosts[0].paths[0].pathType='Prefix',\
             ingress.main.hosts[0].paths[0].service.name=qbittorrent,\
             ingress.main.hosts[0].paths[0].service.port=10095"
 
@@ -227,7 +206,6 @@
       block:
       - name: Install/Upgrade the prowlarr chart
         include_tasks: tasks-install-chart.yaml
-        # https://artifacthub.io/packages/helm/k8s-at-home/prowlarr
         vars:
           repo_name: TrueCharts
           repo_link: https://charts.truecharts.org
@@ -235,43 +213,14 @@
           timeout: "{{ charts.timeout }}"
           release_name: prowlarr
           chart_name: prowlarr
-          # runAsUser={{ uid }} gives write access on the pod
-          # 568 is the default user ID, added to the groups cause why not
-          # The following has been set to disable Truecharts own injection
-          # of manifests for SCALE products I believe
-          # either way I dont need it:
-          # - common.manifests.enabled=false
           set_options: "--set \
-            global.addMetalLBAnnotations=false,\
-            global.addTraefikAnnotations=false,\
-            controller.type=statefulset,\
-            common.persistence.shared.enabled=false,\
-            common.persistence.shm.enabled=false,\
-            common.persistence.temp.enabled=false,\
-            common.persistence.varlogs.enabled=false,\
-            common.manifests.enabled=false,\
-            common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
-            common.podSecurityContext.runAsUser={{ uid }},\
-            common.podSecurityContext.runAsGroup=568,\
-            common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=true,\
-            persistence.config.size=1Gi,\
-            persistence.media.enabled=true,\
-            persistence.media.type=hostPath,\
-            persistence.media.mountPath={{ dir_mount_path }},\
-            persistence.media.hostPath={{ dir_minikube_mount }},\
-            resources.requests.cpu={{ charts.resources.requests.cpu }},\
-            resources.requests.memory={{ charts.resources.requests.memory }},\
-            resources.limits.cpu={{ charts.resources.limits.cpu }},\
-            resources.limits.memory={{ charts.resources.limits.memory }},\
-            ingress.main.enabled=true,\
-            ingress.main.primary=false,\
-            ingress.main.ingressClassName=nginx,\
-            ingress.main.fixedMiddlewares={},\
-            ingress.main.enableFixedMiddlewares=false,\
+            {{ helm_common_general }},\
+            {{ helm_common_persistence }},\
+            {{ helm_common_pod_security_context }},\
+            {{ helm_common_persistence_media }},\
+            {{ helm_common_resources }},\
+            {{ helm_common_ingress }},\
             ingress.main.hosts[0].host='prowlarr.{{ domain_name }}',\
-            ingress.main.hosts[0].paths[0].path='/',\
-            ingress.main.hosts[0].paths[0].pathType='Prefix',\
             ingress.main.hosts[0].paths[0].service.name=prowlarr,\
             ingress.main.hosts[0].paths[0].service.port=9696"
 
@@ -288,7 +237,6 @@
       block:
       - name: Install/Upgrade the radarr chart
         include_tasks: tasks-install-chart.yaml
-        # https://artifacthub.io/packages/helm/k8s-at-home/radarr
         vars:
           repo_name: TrueCharts
           repo_link: https://charts.truecharts.org
@@ -296,43 +244,14 @@
           timeout: "{{ charts.timeout }}"
           release_name: radarr
           chart_name: radarr
-          # runAsUser={{ uid }} gives write access on the pod
-          # 568 is the default user ID, added to the groups cause why not
-          # The following has been set to disable Truecharts own injection
-          # of manifests for SCALE products I believe
-          # either way I dont need it:
-          # - common.manifests.enabled=false
           set_options: "--set \
-            global.addMetalLBAnnotations=false,\
-            global.addTraefikAnnotations=false,\
-            controller.type=statefulset,\
-            common.persistence.shared.enabled=false,\
-            common.persistence.shm.enabled=false,\
-            common.persistence.temp.enabled=false,\
-            common.persistence.varlogs.enabled=false,\
-            common.manifests.enabled=false,\
-            common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
-            common.podSecurityContext.runAsUser={{ uid }},\
-            common.podSecurityContext.runAsGroup=568,\
-            common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=true,\
-            persistence.config.size=1Gi,\
-            persistence.media.enabled=true,\
-            persistence.media.type=hostPath,\
-            persistence.media.mountPath={{ dir_mount_path }},\
-            persistence.media.hostPath={{ dir_minikube_mount }},\
-            resources.requests.cpu={{ charts.resources.requests.cpu }},\
-            resources.requests.memory={{ charts.resources.requests.memory }},\
-            resources.limits.cpu={{ charts.resources.limits.cpu }},\
-            resources.limits.memory={{ charts.resources.limits.memory }},\
-            ingress.main.enabled=true,\
-            ingress.main.primary=false,\
-            ingress.main.ingressClassName=nginx,\
-            ingress.main.fixedMiddlewares={},\
-            ingress.main.enableFixedMiddlewares=false,\
+            {{ helm_common_general }},\
+            {{ helm_common_persistence }},\
+            {{ helm_common_pod_security_context }},\
+            {{ helm_common_persistence_media }},\
+            {{ helm_common_resources }},\
+            {{ helm_common_ingress }},\
             ingress.main.hosts[0].host='radarr.{{ domain_name }}',\
-            ingress.main.hosts[0].paths[0].path='/',\
-            ingress.main.hosts[0].paths[0].pathType='Prefix',\
             ingress.main.hosts[0].paths[0].service.name=radarr,\
             ingress.main.hosts[0].paths[0].service.port=7878"
 
@@ -348,7 +267,6 @@
       block:
       - name: Install/Upgrade the sonarr chart
         include_tasks: tasks-install-chart.yaml
-        # https://artifacthub.io/packages/helm/k8s-at-home/sonarr
         vars:
           repo_name: TrueCharts
           repo_link: https://charts.truecharts.org
@@ -356,43 +274,14 @@
           timeout: "{{ charts.timeout }}"
           release_name: sonarr
           chart_name: sonarr
-          # runAsUser={{ uid }} gives write access on the pod
-          # 568 is the default user ID, added to the groups cause why not
-          # The following has been set to disable Truecharts own injection
-          # of manifests for SCALE products I believe
-          # either way I dont need it:
-          # - common.manifests.enabled=false
           set_options: "--set \
-            global.addMetalLBAnnotations=false,\
-            global.addTraefikAnnotations=false,\
-            controller.type=statefulset,\
-            common.persistence.shared.enabled=false,\
-            common.persistence.shm.enabled=false,\
-            common.persistence.temp.enabled=false,\
-            common.persistence.varlogs.enabled=false,\
-            common.manifests.enabled=false,\
-            common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
-            common.podSecurityContext.runAsUser={{ uid }},\
-            common.podSecurityContext.runAsGroup=568,\
-            common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=true,\
-            persistence.config.size=1Gi,\
-            persistence.media.enabled=true,\
-            persistence.media.type=hostPath,\
-            persistence.media.mountPath={{ dir_mount_path }},\
-            persistence.media.hostPath={{ dir_minikube_mount }},\
-            resources.requests.cpu={{ charts.resources.requests.cpu }},\
-            resources.requests.memory={{ charts.resources.requests.memory }},\
-            resources.limits.cpu={{ charts.resources.limits.cpu }},\
-            resources.limits.memory={{ charts.resources.limits.memory }},\
-            ingress.main.enabled=true,\
-            ingress.main.primary=false,\
-            ingress.main.ingressClassName=nginx,\
-            ingress.main.fixedMiddlewares={},\
-            ingress.main.enableFixedMiddlewares=false,\
+            {{ helm_common_general }},\
+            {{ helm_common_persistence }},\
+            {{ helm_common_pod_security_context }},\
+            {{ helm_common_persistence_media }},\
+            {{ helm_common_resources }},\
+            {{ helm_common_ingress }},\
             ingress.main.hosts[0].host='sonarr.{{ domain_name }}',\
-            ingress.main.hosts[0].paths[0].path='/',\
-            ingress.main.hosts[0].paths[0].pathType='Prefix',\
             ingress.main.hosts[0].paths[0].service.name=sonarr,\
             ingress.main.hosts[0].paths[0].service.port=8989"
 
@@ -408,7 +297,6 @@
       block:
       - name: Install/Upgrade the bazarr chart
         include_tasks: tasks-install-chart.yaml
-        # https://artifacthub.io/packages/helm/k8s-at-home/bazarr
         vars:
           repo_name: TrueCharts
           repo_link: https://charts.truecharts.org
@@ -416,43 +304,14 @@
           timeout: "{{ charts.timeout }}"
           release_name: bazarr
           chart_name: bazarr
-          # runAsUser={{ uid }} gives write access on the pod
-          # 568 is the default user ID, added to the groups cause why not
-          # The following has been set to disable Truecharts own injection
-          # of manifests for SCALE products I believe
-          # either way I dont need it:
-          # - common.manifests.enabled=false
           set_options: "--set \
-            global.addMetalLBAnnotations=false,\
-            global.addTraefikAnnotations=false,\
-            controller.type=statefulset,\
-            common.persistence.shared.enabled=false,\
-            common.persistence.shm.enabled=false,\
-            common.persistence.temp.enabled=false,\
-            common.persistence.varlogs.enabled=false,\
-            common.manifests.enabled=false,\
-            common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
-            common.podSecurityContext.runAsUser={{ uid }},\
-            common.podSecurityContext.runAsGroup=568,\
-            common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=true,\
-            persistence.config.size=1Gi,\
-            persistence.media.enabled=true,\
-            persistence.media.type=hostPath,\
-            persistence.media.mountPath={{ dir_mount_path }},\
-            persistence.media.hostPath={{ dir_minikube_mount }},\
-            resources.requests.cpu={{ charts.resources.requests.cpu }},\
-            resources.requests.memory={{ charts.resources.requests.memory }},\
-            resources.limits.cpu={{ charts.resources.limits.cpu }},\
-            resources.limits.memory={{ charts.resources.limits.memory }},\
-            ingress.main.enabled=true,\
-            ingress.main.primary=false,\
-            ingress.main.ingressClassName=nginx,\
-            ingress.main.fixedMiddlewares={},\
-            ingress.main.enableFixedMiddlewares=false,\
+            {{ helm_common_general }},\
+            {{ helm_common_persistence }},\
+            {{ helm_common_pod_security_context }},\
+            {{ helm_common_persistence_media }},\
+            {{ helm_common_resources }},\
+            {{ helm_common_ingress }},\
             ingress.main.hosts[0].host='bazarr.{{ domain_name }}',\
-            ingress.main.hosts[0].paths[0].path='/',\
-            ingress.main.hosts[0].paths[0].pathType='Prefix',\
             ingress.main.hosts[0].paths[0].service.name=bazarr,\
             ingress.main.hosts[0].paths[0].service.port=6767"
 
@@ -467,7 +326,6 @@
       block:
       - name: Install/Upgrade the readarr chart
         include_tasks: tasks-install-chart.yaml
-        # https://artifacthub.io/packages/helm/k8s-at-home/readarr
         vars:
           repo_name: TrueCharts
           repo_link: https://charts.truecharts.org
@@ -475,43 +333,14 @@
           timeout: "{{ charts.timeout }}"
           release_name: readarr
           chart_name: readarr
-          # runAsUser={{ uid }} gives write access on the pod
-          # 568 is the default user ID, added to the groups cause why not
-          # The following has been set to disable Truecharts own injection
-          # of manifests for SCALE products I believe
-          # either way I dont need it:
-          # - common.manifests.enabled=false
           set_options: "--set \
-            global.addMetalLBAnnotations=false,\
-            global.addTraefikAnnotations=false,\
-            controller.type=statefulset,\
-            common.persistence.shared.enabled=false,\
-            common.persistence.shm.enabled=false,\
-            common.persistence.temp.enabled=false,\
-            common.persistence.varlogs.enabled=false,\
-            common.manifests.enabled=false,\
-            common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
-            common.podSecurityContext.runAsUser={{ uid }},\
-            common.podSecurityContext.runAsGroup=568,\
-            common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=true,\
-            persistence.config.size=1Gi,\
-            persistence.media.enabled=true,\
-            persistence.media.type=hostPath,\
-            persistence.media.mountPath={{ dir_mount_path }},\
-            persistence.media.hostPath={{ dir_minikube_mount }},\
-            resources.requests.cpu={{ charts.resources.requests.cpu }},\
-            resources.requests.memory={{ charts.resources.requests.memory }},\
-            resources.limits.cpu={{ charts.resources.limits.cpu }},\
-            resources.limits.memory={{ charts.resources.limits.memory }},\
-            ingress.main.enabled=true,\
-            ingress.main.primary=false,\
-            ingress.main.ingressClassName=nginx,\
-            ingress.main.fixedMiddlewares={},\
-            ingress.main.enableFixedMiddlewares=false,\
+            {{ helm_common_general }},\
+            {{ helm_common_persistence }},\
+            {{ helm_common_pod_security_context }},\
+            {{ helm_common_persistence_media }},\
+            {{ helm_common_resources }},\
+            {{ helm_common_ingress }},\
             ingress.main.hosts[0].host='readarr.{{ domain_name }}',\
-            ingress.main.hosts[0].paths[0].path='/',\
-            ingress.main.hosts[0].paths[0].pathType='Prefix',\
             ingress.main.hosts[0].paths[0].service.name=readarr,\
             ingress.main.hosts[0].paths[0].service.port=8787"
 
@@ -526,7 +355,6 @@
       block:
       - name: Install/Upgrade the lidarr chart
         include_tasks: tasks-install-chart.yaml
-        # https://artifacthub.io/packages/helm/k8s-at-home/lidarr
         vars:
           repo_name: TrueCharts
           repo_link: https://charts.truecharts.org
@@ -534,43 +362,14 @@
           timeout: "{{ charts.timeout }}"
           release_name: lidarr
           chart_name: lidarr
-          # runAsUser={{ uid }} gives write access on the pod
-          # 568 is the default user ID, added to the groups cause why not
-          # The following has been set to disable Truecharts own injection
-          # of manifests for SCALE products I believe
-          # either way I dont need it:
-          # - common.manifests.enabled=false
           set_options: "--set \
-            global.addMetalLBAnnotations=false,\
-            global.addTraefikAnnotations=false,\
-            controller.type=statefulset,\
-            common.persistence.shared.enabled=false,\
-            common.persistence.shm.enabled=false,\
-            common.persistence.temp.enabled=false,\
-            common.persistence.varlogs.enabled=false,\
-            common.manifests.enabled=false,\
-            common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
-            common.podSecurityContext.runAsUser={{ uid }},\
-            common.podSecurityContext.runAsGroup=568,\
-            common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=true,\
-            persistence.config.size=1Gi,\
-            persistence.media.enabled=true,\
-            persistence.media.type=hostPath,\
-            persistence.media.mountPath={{ dir_mount_path }},\
-            persistence.media.hostPath={{ dir_minikube_mount }},\
-            resources.requests.cpu={{ charts.resources.requests.cpu }},\
-            resources.requests.memory={{ charts.resources.requests.memory }},\
-            resources.limits.cpu={{ charts.resources.limits.cpu }},\
-            resources.limits.memory={{ charts.resources.limits.memory }},\
-            ingress.main.enabled=true,\
-            ingress.main.primary=false,\
-            ingress.main.ingressClassName=nginx,\
-            ingress.main.fixedMiddlewares={},\
-            ingress.main.enableFixedMiddlewares=false,\
+            {{ helm_common_general }},\
+            {{ helm_common_persistence }},\
+            {{ helm_common_pod_security_context }},\
+            {{ helm_common_persistence_media }},\
+            {{ helm_common_resources }},\
+            {{ helm_common_ingress }},\
             ingress.main.hosts[0].host='lidarr.{{ domain_name }}',\
-            ingress.main.hosts[0].paths[0].path='/',\
-            ingress.main.hosts[0].paths[0].pathType='Prefix',\
             ingress.main.hosts[0].paths[0].service.name=lidarr,\
             ingress.main.hosts[0].paths[0].service.port=8686"
 
@@ -581,7 +380,6 @@
             can be used by the application.
 
     - name: Install ombi
-      # https://artifacthub.io/packages/helm/k8s-at-home/ombi
       when: charts.services.ombi
       block:
       - name: Install/Upgrade the ombi chart
@@ -593,37 +391,13 @@
           timeout: "{{ charts.timeout }}"
           release_name: ombi
           chart_name: ombi
-          # The following has been set to disable Truecharts own injection
-          # of manifests for SCALE products I believe
-          # either way I dont need it:
-          # - common.manifests.enabled=false
           set_options: "--set \
-            global.addMetalLBAnnotations=false,\
-            global.addTraefikAnnotations=false,\
-            controller.type=statefulset,\
-            common.persistence.shared.enabled=false,\
-            common.persistence.shm.enabled=false,\
-            common.persistence.temp.enabled=false,\
-            common.persistence.varlogs.enabled=false,\
-            common.manifests.enabled=false,\
-            common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
-            common.podSecurityContext.runAsUser={{ uid }},\
-            common.podSecurityContext.runAsGroup=568,\
-            common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=true,\
-            persistence.config.size=1Gi,\
-            resources.requests.cpu={{ charts.resources.requests.cpu }},\
-            resources.requests.memory={{ charts.resources.requests.memory }},\
-            resources.limits.cpu={{ charts.resources.limits.cpu }},\
-            resources.limits.memory={{ charts.resources.limits.memory }},\
-            ingress.main.enabled=true,\
-            ingress.main.primary=false,\
-            ingress.main.ingressClassName=nginx,\
-            ingress.main.fixedMiddlewares={},\
-            ingress.main.enableFixedMiddlewares=false,\
+            {{ helm_common_general }},\
+            {{ helm_common_persistence }},\
+            {{ helm_common_pod_security_context }},\
+            {{ helm_common_resources }},\
+            {{ helm_common_ingress }},\
             ingress.main.hosts[0].host='ombi.{{ domain_name }}',\
-            ingress.main.hosts[0].paths[0].path='/',\
-            ingress.main.hosts[0].paths[0].pathType='Prefix',\
             ingress.main.hosts[0].paths[0].service.name=ombi,\
             ingress.main.hosts[0].paths[0].service.port=3579"
 
@@ -639,7 +413,6 @@
       block:
       - name: Install/Upgrade the librespeed chart
         include_tasks: tasks-install-chart.yaml
-        # https://artifacthub.io/packages/helm/k8s-at-home/librespeed
         vars:
           repo_name: TrueCharts
           repo_link: https://charts.truecharts.org
@@ -647,37 +420,17 @@
           timeout: "{{ charts.timeout }}"
           release_name: librespeed
           chart_name: librespeed
-          # The following has been set to disable Truecharts own injection
-          # of manifests for SCALE products I believe
-          # either way I dont need it:
-          # - common.manifests.enabled=false
+          # PUID={{ uid }} gives write access on the pod
+          # 568 is the default user ID, added to the groups cause why not
           set_options: "--set \
-            global.addMetalLBAnnotations=false,\
-            global.addTraefikAnnotations=false,\
-            controller.type=statefulset,\
-            common.persistence.shared.enabled=false,\
-            common.persistence.shm.enabled=false,\
-            common.persistence.temp.enabled=false,\
-            common.persistence.varlogs.enabled=false,\
-            common.manifests.enabled=false,\
-            common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
+            {{ helm_common_general }},\
+            {{ helm_common_persistence }},\
+            {{ helm_common_resources }},\
+            {{ helm_common_ingress }},\
             env.PUID=\"{{ uid }}\",\
             env.PGID=\"568\",\
             common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=true,\
-            persistence.config.size=1Gi,\
-            resources.requests.cpu={{ charts.resources.requests.cpu }},\
-            resources.requests.memory={{ charts.resources.requests.memory }},\
-            resources.limits.cpu={{ charts.resources.limits.cpu }},\
-            resources.limits.memory={{ charts.resources.limits.memory }},\
-            ingress.main.enabled=true,\
-            ingress.main.primary=false,\
-            ingress.main.ingressClassName=nginx,\
-            ingress.main.fixedMiddlewares={},\
-            ingress.main.enableFixedMiddlewares=false,\
             ingress.main.hosts[0].host='librespeed.{{ domain_name }}',\
-            ingress.main.hosts[0].paths[0].path='/',\
-            ingress.main.hosts[0].paths[0].pathType='Prefix',\
             ingress.main.hosts[0].paths[0].service.name=librespeed,\
             ingress.main.hosts[0].paths[0].service.port=10016"
 
@@ -690,7 +443,6 @@
       block:
       - name: Install/Upgrade the calibre-web chart
         include_tasks: tasks-install-chart.yaml
-        # https://artifacthub.io/packages/helm/k8s-at-home/calibre-web
         vars:
           repo_name: TrueCharts
           repo_link: https://charts.truecharts.org
@@ -700,41 +452,16 @@
           chart_name: calibre-web
           # PUID={{ uid }} gives write access on the pod
           # 568 is the default user ID, added to the groups cause why not
-          # The following has been set to disable Truecharts own injection
-          # of manifests for SCALE products I believe
-          # either way I dont need it:
-          # - common.manifests.enabled=false
           set_options: "--set \
-            global.addMetalLBAnnotations=false,\
-            global.addTraefikAnnotations=false,\
-            controller.type=statefulset,\
-            common.persistence.shared.enabled=false,\
-            common.persistence.shm.enabled=false,\
-            common.persistence.temp.enabled=false,\
-            common.persistence.varlogs.enabled=false,\
-            common.manifests.enabled=false,\
-            common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
+            {{ helm_common_general }},\
+            {{ helm_common_persistence }},\
+            {{ helm_common_persistence_media }},\
+            {{ helm_common_resources }},\
+            {{ helm_common_ingress }},\
             env.PUID=\"{{ uid }}\",\
             env.PGID=\"568\",\
             podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=true,\
-            persistence.config.size=1Gi,\
-            persistence.media.enabled=true,\
-            persistence.media.type=hostPath,\
-            persistence.media.mountPath={{ dir_mount_path }},\
-            persistence.media.hostPath={{ dir_minikube_mount }},\
-            resources.requests.cpu={{ charts.resources.requests.cpu }},\
-            resources.requests.memory={{ charts.resources.requests.memory }},\
-            resources.limits.cpu={{ charts.resources.limits.cpu }},\
-            resources.limits.memory={{ charts.resources.limits.memory }},\
-            ingress.main.enabled=true,\
-            ingress.main.primary=false,\
-            ingress.main.ingressClassName=nginx,\
-            ingress.main.fixedMiddlewares={},\
-            ingress.main.enableFixedMiddlewares=false,\
             ingress.main.hosts[0].host='calibre-web.{{ domain_name }}',\
-            ingress.main.hosts[0].paths[0].path='/',\
-            ingress.main.hosts[0].paths[0].pathType='Prefix',\
             ingress.main.hosts[0].paths[0].service.name=calibre-web,\
             ingress.main.hosts[0].paths[0].service.port=8083"
 
@@ -749,7 +476,6 @@
       block:
       - name: Install/Upgrade the calibre chart
         include_tasks: tasks-install-chart.yaml
-        # https://artifacthub.io/packages/helm/k8s-at-home/calibre
         vars:
           repo_name: TrueCharts
           repo_link: https://charts.truecharts.org
@@ -759,33 +485,14 @@
           chart_name: calibre
           # PUID={{ uid }} gives write access on the pod
           # 568 is the default user ID, added to the groups cause why not
-          # The following has been set to disable Truecharts own injection
-          # of manifests for SCALE products I believe
-          # either way I dont need it:
-          # - common.manifests.enabled=false
           set_options: "--set \
-            global.addMetalLBAnnotations=false,\
-            global.addTraefikAnnotations=false,\
-            controller.type=statefulset,\
-            common.persistence.shared.enabled=false,\
-            common.persistence.shm.enabled=false,\
-            common.persistence.temp.enabled=false,\
-            common.persistence.varlogs.enabled=false,\
-            common.manifests.enabled=false,\
-            common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
+            {{ helm_common_general }},\
+            {{ helm_common_persistence }},\
+            {{ helm_common_persistence_media }},\
+            {{ helm_common_resources }},\
             env.PUID=\"{{ uid }}\",\
             env.PGID=\"568\",\
             podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=true,\
-            persistence.config.size=1Gi,\
-            persistence.media.enabled=true,\
-            persistence.media.type=hostPath,\
-            persistence.media.mountPath={{ dir_mount_path }},\
-            persistence.media.hostPath={{ dir_minikube_mount }},\
-            resources.requests.cpu={{ charts.resources.requests.cpu }},\
-            resources.requests.memory={{ charts.resources.requests.memory }},\
-            resources.limits.cpu={{ charts.resources.limits.cpu }},\
-            resources.limits.memory={{ charts.resources.limits.memory }},\
             service.webserver.enabled=true"
 
       - name: Expose calibre service

--- a/install-charts.yaml
+++ b/install-charts.yaml
@@ -138,7 +138,7 @@
             persistence.dev.enabled=true,\
             persistence.dev.type=hostPath,\
             persistence.dev.mountPath=/dev,\
-            persistence.dev.hostPath=/dev,\ # maybe use host-dev
+            persistence.dev.hostPath=/dev,\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\

--- a/install-charts.yaml
+++ b/install-charts.yaml
@@ -62,7 +62,6 @@
           # - common.manifests.enabled=false
           set_options: "--set \
             prometheus.prometheusSpec.retention=730d,\
-            common.manifests.enabled=false,\
             grafana.persistence.enabled=true,\
             prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.accessModes={'ReadWriteOnce'},\
             prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage='50Gi',\
@@ -113,25 +112,34 @@
           # either way I dont need it:
           # - common.manifests.enabled=false
           set_options: "--set \
+            global.addMetalLBAnnotations=false,\
+            global.addTraefikAnnotations=false,\
             controller.type=statefulset,\
+            common.persistence.shared.enabled=false,\
+            common.persistence.shm.enabled=false,\
+            common.persistence.temp.enabled=false,\
+            common.persistence.varlogs.enabled=false,\
             common.manifests.enabled=false,\
             common.securityContext.privileged=true,\
             common.securityContext.allowPrivilegeEscalation=true,\
-            persistence.config.enabled=yes,\
+            persistence.config.enabled=true,\
+            persistence.config.size=1Gi,\
             persistence.cache.enabled=true,\
             persistence.cache.accessMode=ReadWriteOnce,\
             persistence.cache.size=50G,\
-            persistence.media.enabled=yes,\
+            persistence.media.enabled=true,\
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
-            persistence.dev.enabled=yes,\
+            persistence.dev.enabled=true,\
             persistence.dev.type=hostPath,\
             persistence.dev.mountPath=/dev,\
-            persistence.dev.hostPath=/dev,\
+            persistence.dev.hostPath=/dev,\ # maybe use host-dev
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
+            ingress.main.fixedMiddlewares={},\
+            ingress.main.enableFixedMiddlewares=false,\
             ingress.main.hosts[0].host='jellyfin.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].path='/',\
             ingress.main.hosts[0].paths[0].pathType='Prefix',\
@@ -165,20 +173,29 @@
           # either way I dont need it:
           # - common.manifests.enabled=false
           set_options: "--set \
+            global.addMetalLBAnnotations=false,\
+            global.addTraefikAnnotations=false,\
             controller.type=statefulset,\
+            common.persistence.shared.enabled=false,\
+            common.persistence.shm.enabled=false,\
+            common.persistence.temp.enabled=false,\
+            common.persistence.varlogs.enabled=false,\
             common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             common.podSecurityContext.runAsUser={{ uid }},\
             common.podSecurityContext.runAsGroup=568,\
             common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=yes,\
-            persistence.media.enabled=yes,\
+            persistence.config.enabled=true,\
+            persistence.config.size=1Gi,\
+            persistence.media.enabled=true,\
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
+            ingress.main.fixedMiddlewares={},\
+            ingress.main.enableFixedMiddlewares=false,\
             ingress.main.hosts[0].host='qbittorrent.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].path='/',\
             ingress.main.hosts[0].paths[0].pathType='Prefix',\
@@ -213,20 +230,29 @@
           # either way I dont need it:
           # - common.manifests.enabled=false
           set_options: "--set \
+            global.addMetalLBAnnotations=false,\
+            global.addTraefikAnnotations=false,\
             controller.type=statefulset,\
+            common.persistence.shared.enabled=false,\
+            common.persistence.shm.enabled=false,\
+            common.persistence.temp.enabled=false,\
+            common.persistence.varlogs.enabled=false,\
             common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             common.podSecurityContext.runAsUser={{ uid }},\
             common.podSecurityContext.runAsGroup=568,\
             common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=yes,\
-            persistence.media.enabled=yes,\
+            persistence.config.enabled=true,\
+            persistence.config.size=1Gi,\
+            persistence.media.enabled=true,\
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
+            ingress.main.fixedMiddlewares={},\
+            ingress.main.enableFixedMiddlewares=false,\
             ingress.main.hosts[0].host='prowlarr.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].path='/',\
             ingress.main.hosts[0].paths[0].pathType='Prefix',\
@@ -261,20 +287,29 @@
           # either way I dont need it:
           # - common.manifests.enabled=false
           set_options: "--set \
+            global.addMetalLBAnnotations=false,\
+            global.addTraefikAnnotations=false,\
             controller.type=statefulset,\
+            common.persistence.shared.enabled=false,\
+            common.persistence.shm.enabled=false,\
+            common.persistence.temp.enabled=false,\
+            common.persistence.varlogs.enabled=false,\
             common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             common.podSecurityContext.runAsUser={{ uid }},\
             common.podSecurityContext.runAsGroup=568,\
             common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=yes,\
-            persistence.media.enabled=yes,\
+            persistence.config.enabled=true,\
+            persistence.config.size=1Gi,\
+            persistence.media.enabled=true,\
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
+            ingress.main.fixedMiddlewares={},\
+            ingress.main.enableFixedMiddlewares=false,\
             ingress.main.hosts[0].host='radarr.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].path='/',\
             ingress.main.hosts[0].paths[0].pathType='Prefix',\
@@ -308,20 +343,29 @@
           # either way I dont need it:
           # - common.manifests.enabled=false
           set_options: "--set \
+            global.addMetalLBAnnotations=false,\
+            global.addTraefikAnnotations=false,\
             controller.type=statefulset,\
+            common.persistence.shared.enabled=false,\
+            common.persistence.shm.enabled=false,\
+            common.persistence.temp.enabled=false,\
+            common.persistence.varlogs.enabled=false,\
             common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             common.podSecurityContext.runAsUser={{ uid }},\
             common.podSecurityContext.runAsGroup=568,\
             common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=yes,\
-            persistence.media.enabled=yes,\
+            persistence.config.enabled=true,\
+            persistence.config.size=1Gi,\
+            persistence.media.enabled=true,\
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
+            ingress.main.fixedMiddlewares={},\
+            ingress.main.enableFixedMiddlewares=false,\
             ingress.main.hosts[0].host='sonarr.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].path='/',\
             ingress.main.hosts[0].paths[0].pathType='Prefix',\
@@ -355,20 +399,29 @@
           # either way I dont need it:
           # - common.manifests.enabled=false
           set_options: "--set \
+            global.addMetalLBAnnotations=false,\
+            global.addTraefikAnnotations=false,\
             controller.type=statefulset,\
+            common.persistence.shared.enabled=false,\
+            common.persistence.shm.enabled=false,\
+            common.persistence.temp.enabled=false,\
+            common.persistence.varlogs.enabled=false,\
             common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             common.podSecurityContext.runAsUser={{ uid }},\
             common.podSecurityContext.runAsGroup=568,\
             common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=yes,\
-            persistence.media.enabled=yes,\
+            persistence.config.enabled=true,\
+            persistence.config.size=1Gi,\
+            persistence.media.enabled=true,\
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
+            ingress.main.fixedMiddlewares={},\
+            ingress.main.enableFixedMiddlewares=false,\
             ingress.main.hosts[0].host='bazarr.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].path='/',\
             ingress.main.hosts[0].paths[0].pathType='Prefix',\
@@ -401,20 +454,29 @@
           # either way I dont need it:
           # - common.manifests.enabled=false
           set_options: "--set \
+            global.addMetalLBAnnotations=false,\
+            global.addTraefikAnnotations=false,\
             controller.type=statefulset,\
+            common.persistence.shared.enabled=false,\
+            common.persistence.shm.enabled=false,\
+            common.persistence.temp.enabled=false,\
+            common.persistence.varlogs.enabled=false,\
             common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             common.podSecurityContext.runAsUser={{ uid }},\
             common.podSecurityContext.runAsGroup=568,\
             common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=yes,\
-            persistence.media.enabled=yes,\
+            persistence.config.enabled=true,\
+            persistence.config.size=1Gi,\
+            persistence.media.enabled=true,\
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
+            ingress.main.fixedMiddlewares={},\
+            ingress.main.enableFixedMiddlewares=false,\
             ingress.main.hosts[0].host='readarr.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].path='/',\
             ingress.main.hosts[0].paths[0].pathType='Prefix',\
@@ -447,20 +509,29 @@
           # either way I dont need it:
           # - common.manifests.enabled=false
           set_options: "--set \
+            global.addMetalLBAnnotations=false,\
+            global.addTraefikAnnotations=false,\
             controller.type=statefulset,\
+            common.persistence.shared.enabled=false,\
+            common.persistence.shm.enabled=false,\
+            common.persistence.temp.enabled=false,\
+            common.persistence.varlogs.enabled=false,\
             common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             common.podSecurityContext.runAsUser={{ uid }},\
             common.podSecurityContext.runAsGroup=568,\
             common.podSecurityContext.fsGroup=568,\
-            persistence.config.enabled=yes,\
-            persistence.media.enabled=yes,\
+            persistence.config.enabled=true,\
+            persistence.config.size=1Gi,\
+            persistence.media.enabled=true,\
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
+            ingress.main.fixedMiddlewares={},\
+            ingress.main.enableFixedMiddlewares=false,\
             ingress.main.hosts[0].host='lidarr.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].path='/',\
             ingress.main.hosts[0].paths[0].pathType='Prefix',\
@@ -491,12 +562,21 @@
           # either way I dont need it:
           # - common.manifests.enabled=false
           set_options: "--set \
+            global.addMetalLBAnnotations=false,\
+            global.addTraefikAnnotations=false,\
             controller.type=statefulset,\
+            common.persistence.shared.enabled=false,\
+            common.persistence.shm.enabled=false,\
+            common.persistence.temp.enabled=false,\
+            common.persistence.varlogs.enabled=false,\
             common.manifests.enabled=false,\
-            persistence.config.enabled=yes,\
+            persistence.config.enabled=true,\
+            persistence.config.size=1Gi,\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
+            ingress.main.fixedMiddlewares={},\
+            ingress.main.enableFixedMiddlewares=false,\
             ingress.main.hosts[0].host='ombi.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].path='/',\
             ingress.main.hosts[0].paths[0].pathType='Prefix',\
@@ -528,13 +608,22 @@
           # either way I dont need it:
           # - common.manifests.enabled=false
           set_options: "--set \
+            global.addMetalLBAnnotations=false,\
+            global.addTraefikAnnotations=false,\
             controller.type=statefulset,\
+            common.persistence.shared.enabled=false,\
+            common.persistence.shm.enabled=false,\
+            common.persistence.temp.enabled=false,\
+            common.persistence.varlogs.enabled=false,\
             common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
-            persistence.config.enabled=yes,\
+            persistence.config.enabled=true,\
+            persistence.config.size=1Gi,\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
+            ingress.main.fixedMiddlewares={},\
+            ingress.main.enableFixedMiddlewares=false,\
             ingress.main.hosts[0].host='librespeed.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].path='/',\
             ingress.main.hosts[0].paths[0].pathType='Prefix',\
@@ -565,19 +654,28 @@
           # either way I dont need it:
           # - common.manifests.enabled=false
           set_options: "--set \
+            global.addMetalLBAnnotations=false,\
+            global.addTraefikAnnotations=false,\
             controller.type=statefulset,\
+            common.persistence.shared.enabled=false,\
+            common.persistence.shm.enabled=false,\
+            common.persistence.temp.enabled=false,\
+            common.persistence.varlogs.enabled=false,\
             common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             env.PUID=\"{{ uid }}\",\
             env.PGID=\"568\",\
-            persistence.config.enabled=yes,\
-            persistence.media.enabled=yes,\
+            persistence.config.enabled=true,\
+            persistence.config.size=1Gi,\
+            persistence.media.enabled=true,\
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
             ingress.main.ingressClassName=nginx,\
+            ingress.main.fixedMiddlewares={},\
+            ingress.main.enableFixedMiddlewares=false,\
             ingress.main.hosts[0].host='calibre-web.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].path='/',\
             ingress.main.hosts[0].paths[0].pathType='Prefix',\
@@ -610,13 +708,20 @@
           # either way I dont need it:
           # - common.manifests.enabled=false
           set_options: "--set \
+            global.addMetalLBAnnotations=false,\
+            global.addTraefikAnnotations=false,\
             controller.type=statefulset,\
+            common.persistence.shared.enabled=false,\
+            common.persistence.shm.enabled=false,\
+            common.persistence.temp.enabled=false,\
+            common.persistence.varlogs.enabled=false,\
             common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             env.PUID=\"{{ uid }}\",\
             env.PGID=\"568\",\
-            persistence.config.enabled=yes,\
-            persistence.media.enabled=yes,\
+            persistence.config.enabled=true,\
+            persistence.config.size=1Gi,\
+            persistence.media.enabled=true,\
             persistence.media.type=hostPath,\
             persistence.media.mountPath={{ dir_mount_path }},\
             persistence.media.hostPath={{ dir_minikube_mount }},\

--- a/install-charts.yaml
+++ b/install-charts.yaml
@@ -125,7 +125,7 @@
       - debug:
           msg: >
             You can log into Grafana at 'grafana.{{ domain_name }}' using
-            admin/{{ default_grafana_admin_password }}"
+            admin/{{ default_grafana_admin_password }}
 
     - name: Install jellyfin
       when: charts.services.jellyfin

--- a/install-charts.yaml
+++ b/install-charts.yaml
@@ -56,8 +56,13 @@
           timeout: "{{ charts.timeout }}"
           release_name: kube-prometheus-stack
           chart_name: kube-prometheus-stack
+          # The following has been set to disable Truecharts own injection
+          # of manifests for SCALE products I believe
+          # either way I dont need it:
+          # - common.manifests.enabled=false
           set_options: "--set \
             prometheus.prometheusSpec.retention=730d,\
+            common.manifests.enabled=false,\
             grafana.persistence.enabled=true,\
             prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.accessModes={'ReadWriteOnce'},\
             prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage='50Gi',\
@@ -93,18 +98,25 @@
       - name: Install/Upgrade the jellyfin chart
         include_tasks: tasks-install-chart.yaml
         vars:
-          repo_name: k8s-at-home
-          repo_link: https://k8s-at-home.com/charts/
+          repo_name: TrueCharts
+          repo_link: https://charts.truecharts.org
           install_namespace: "{{ namespace_generic_services }}"
           timeout: "{{ charts.timeout }}"
           release_name: jellyfin
           chart_name: jellyfin
-          # "common.securityContext.privileged=true" is to allow the pod
-          # to be able to use the dev mount to access /dev/dri/renderD128 for
-          # hwa
+          # to allow the pod # to be able to use the /dev mount
+          # to access /dev/dri/renderD128 for hwa, these options are set to true
+          # - common.securityContext.privileged=true
+          # - common.securityContext.allowPrivilegeEscalation=true
+          # The following has been set to disable Truecharts own injection
+          # of manifests for SCALE products I believe
+          # either way I dont need it:
+          # - common.manifests.enabled=false
           set_options: "--set \
             controller.type=statefulset,\
+            common.manifests.enabled=false,\
             common.securityContext.privileged=true,\
+            common.securityContext.allowPrivilegeEscalation=true,\
             persistence.config.enabled=yes,\
             persistence.cache.enabled=true,\
             persistence.cache.accessMode=ReadWriteOnce,\
@@ -140,16 +152,21 @@
         include_tasks: tasks-install-chart.yaml
         # https://artifacthub.io/packages/helm/k8s-at-home/qbittorrent
         vars:
-          repo_name: k8s-at-home
-          repo_link: https://k8s-at-home.com/charts/
+          repo_name: TrueCharts
+          repo_link: https://charts.truecharts.org
           install_namespace: "{{ namespace_generic_services }}"
           timeout: "{{ charts.timeout }}"
           release_name: qbittorrent
           chart_name: qbittorrent
           # runAsUser={{ uid }} gives write access on the pod
           # 568 is the default user ID, added to the groups cause why not
+          # The following has been set to disable Truecharts own injection
+          # of manifests for SCALE products I believe
+          # either way I dont need it:
+          # - common.manifests.enabled=false
           set_options: "--set \
             controller.type=statefulset,\
+            common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             common.podSecurityContext.runAsUser={{ uid }},\
             common.podSecurityContext.runAsGroup=568,\
@@ -166,7 +183,7 @@
             ingress.main.hosts[0].paths[0].path='/',\
             ingress.main.hosts[0].paths[0].pathType='Prefix',\
             ingress.main.hosts[0].paths[0].service.name=qbittorrent,\
-            ingress.main.hosts[0].paths[0].service.port=8080"
+            ingress.main.hosts[0].paths[0].service.port=10095"
 
       - debug:
           msg: >
@@ -183,16 +200,21 @@
         include_tasks: tasks-install-chart.yaml
         # https://artifacthub.io/packages/helm/k8s-at-home/prowlarr
         vars:
-          repo_name: k8s-at-home
-          repo_link: https://k8s-at-home.com/charts/
+          repo_name: TrueCharts
+          repo_link: https://charts.truecharts.org
           install_namespace: "{{ namespace_generic_services }}"
           timeout: "{{ charts.timeout }}"
           release_name: prowlarr
           chart_name: prowlarr
           # runAsUser={{ uid }} gives write access on the pod
           # 568 is the default user ID, added to the groups cause why not
+          # The following has been set to disable Truecharts own injection
+          # of manifests for SCALE products I believe
+          # either way I dont need it:
+          # - common.manifests.enabled=false
           set_options: "--set \
             controller.type=statefulset,\
+            common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             common.podSecurityContext.runAsUser={{ uid }},\
             common.podSecurityContext.runAsGroup=568,\
@@ -226,16 +248,21 @@
         include_tasks: tasks-install-chart.yaml
         # https://artifacthub.io/packages/helm/k8s-at-home/radarr
         vars:
-          repo_name: k8s-at-home
-          repo_link: https://k8s-at-home.com/charts/
+          repo_name: TrueCharts
+          repo_link: https://charts.truecharts.org
           install_namespace: "{{ namespace_generic_services }}"
           timeout: "{{ charts.timeout }}"
           release_name: radarr
           chart_name: radarr
           # runAsUser={{ uid }} gives write access on the pod
           # 568 is the default user ID, added to the groups cause why not
+          # The following has been set to disable Truecharts own injection
+          # of manifests for SCALE products I believe
+          # either way I dont need it:
+          # - common.manifests.enabled=false
           set_options: "--set \
             controller.type=statefulset,\
+            common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             common.podSecurityContext.runAsUser={{ uid }},\
             common.podSecurityContext.runAsGroup=568,\
@@ -268,16 +295,21 @@
         include_tasks: tasks-install-chart.yaml
         # https://artifacthub.io/packages/helm/k8s-at-home/sonarr
         vars:
-          repo_name: k8s-at-home
-          repo_link: https://k8s-at-home.com/charts/
+          repo_name: TrueCharts
+          repo_link: https://charts.truecharts.org
           install_namespace: "{{ namespace_generic_services }}"
           timeout: "{{ charts.timeout }}"
           release_name: sonarr
           chart_name: sonarr
           # runAsUser={{ uid }} gives write access on the pod
           # 568 is the default user ID, added to the groups cause why not
+          # The following has been set to disable Truecharts own injection
+          # of manifests for SCALE products I believe
+          # either way I dont need it:
+          # - common.manifests.enabled=false
           set_options: "--set \
             controller.type=statefulset,\
+            common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             common.podSecurityContext.runAsUser={{ uid }},\
             common.podSecurityContext.runAsGroup=568,\
@@ -310,16 +342,21 @@
         include_tasks: tasks-install-chart.yaml
         # https://artifacthub.io/packages/helm/k8s-at-home/bazarr
         vars:
-          repo_name: k8s-at-home
-          repo_link: https://k8s-at-home.com/charts/
+          repo_name: TrueCharts
+          repo_link: https://charts.truecharts.org
           install_namespace: "{{ namespace_generic_services }}"
           timeout: "{{ charts.timeout }}"
           release_name: bazarr
           chart_name: bazarr
           # runAsUser={{ uid }} gives write access on the pod
           # 568 is the default user ID, added to the groups cause why not
+          # The following has been set to disable Truecharts own injection
+          # of manifests for SCALE products I believe
+          # either way I dont need it:
+          # - common.manifests.enabled=false
           set_options: "--set \
             controller.type=statefulset,\
+            common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             common.podSecurityContext.runAsUser={{ uid }},\
             common.podSecurityContext.runAsGroup=568,\
@@ -351,16 +388,21 @@
         include_tasks: tasks-install-chart.yaml
         # https://artifacthub.io/packages/helm/k8s-at-home/readarr
         vars:
-          repo_name: k8s-at-home
-          repo_link: https://k8s-at-home.com/charts/
+          repo_name: TrueCharts
+          repo_link: https://charts.truecharts.org
           install_namespace: "{{ namespace_generic_services }}"
           timeout: "{{ charts.timeout }}"
           release_name: readarr
           chart_name: readarr
           # runAsUser={{ uid }} gives write access on the pod
           # 568 is the default user ID, added to the groups cause why not
+          # The following has been set to disable Truecharts own injection
+          # of manifests for SCALE products I believe
+          # either way I dont need it:
+          # - common.manifests.enabled=false
           set_options: "--set \
             controller.type=statefulset,\
+            common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             common.podSecurityContext.runAsUser={{ uid }},\
             common.podSecurityContext.runAsGroup=568,\
@@ -392,16 +434,21 @@
         include_tasks: tasks-install-chart.yaml
         # https://artifacthub.io/packages/helm/k8s-at-home/lidarr
         vars:
-          repo_name: k8s-at-home
-          repo_link: https://k8s-at-home.com/charts/
+          repo_name: TrueCharts
+          repo_link: https://charts.truecharts.org
           install_namespace: "{{ namespace_generic_services }}"
           timeout: "{{ charts.timeout }}"
           release_name: lidarr
           chart_name: lidarr
           # runAsUser={{ uid }} gives write access on the pod
           # 568 is the default user ID, added to the groups cause why not
+          # The following has been set to disable Truecharts own injection
+          # of manifests for SCALE products I believe
+          # either way I dont need it:
+          # - common.manifests.enabled=false
           set_options: "--set \
             controller.type=statefulset,\
+            common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             common.podSecurityContext.runAsUser={{ uid }},\
             common.podSecurityContext.runAsGroup=568,\
@@ -433,14 +480,19 @@
       - name: Install/Upgrade the ombi chart
         include_tasks: tasks-install-chart.yaml
         vars:
-          repo_name: k8s-at-home
-          repo_link: https://k8s-at-home.com/charts/
+          repo_name: TrueCharts
+          repo_link: https://charts.truecharts.org
           install_namespace: "{{ namespace_generic_services }}"
           timeout: "{{ charts.timeout }}"
           release_name: ombi
           chart_name: ombi
+          # The following has been set to disable Truecharts own injection
+          # of manifests for SCALE products I believe
+          # either way I dont need it:
+          # - common.manifests.enabled=false
           set_options: "--set \
             controller.type=statefulset,\
+            common.manifests.enabled=false,\
             persistence.config.enabled=yes,\
             ingress.main.enabled=true,\
             ingress.main.primary=false,\
@@ -465,14 +517,19 @@
         include_tasks: tasks-install-chart.yaml
         # https://artifacthub.io/packages/helm/k8s-at-home/librespeed
         vars:
-          repo_name: k8s-at-home
-          repo_link: https://k8s-at-home.com/charts/
+          repo_name: TrueCharts
+          repo_link: https://charts.truecharts.org
           install_namespace: "{{ namespace_generic_services }}"
           timeout: "{{ charts.timeout }}"
           release_name: librespeed
           chart_name: librespeed
+          # The following has been set to disable Truecharts own injection
+          # of manifests for SCALE products I believe
+          # either way I dont need it:
+          # - common.manifests.enabled=false
           set_options: "--set \
             controller.type=statefulset,\
+            common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             persistence.config.enabled=yes,\
             ingress.main.enabled=true,\
@@ -482,7 +539,7 @@
             ingress.main.hosts[0].paths[0].path='/',\
             ingress.main.hosts[0].paths[0].pathType='Prefix',\
             ingress.main.hosts[0].paths[0].service.name=librespeed,\
-            ingress.main.hosts[0].paths[0].service.port=80"
+            ingress.main.hosts[0].paths[0].service.port=10016"
 
       - debug:
           msg: >
@@ -495,16 +552,21 @@
         include_tasks: tasks-install-chart.yaml
         # https://artifacthub.io/packages/helm/k8s-at-home/calibre-web
         vars:
-          repo_name: k8s-at-home
-          repo_link: https://k8s-at-home.com/charts/
+          repo_name: TrueCharts
+          repo_link: https://charts.truecharts.org
           install_namespace: "{{ namespace_generic_services }}"
           timeout: "{{ charts.timeout }}"
           release_name: calibre-web
           chart_name: calibre-web
           # PUID={{ uid }} gives write access on the pod
           # 568 is the default user ID, added to the groups cause why not
+          # The following has been set to disable Truecharts own injection
+          # of manifests for SCALE products I believe
+          # either way I dont need it:
+          # - common.manifests.enabled=false
           set_options: "--set \
             controller.type=statefulset,\
+            common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             env.PUID=\"{{ uid }}\",\
             env.PGID=\"568\",\
@@ -535,16 +597,21 @@
         include_tasks: tasks-install-chart.yaml
         # https://artifacthub.io/packages/helm/k8s-at-home/calibre
         vars:
-          repo_name: k8s-at-home
-          repo_link: https://k8s-at-home.com/charts/
+          repo_name: TrueCharts
+          repo_link: https://charts.truecharts.org
           install_namespace: "{{ namespace_generic_services }}"
           timeout: "{{ charts.timeout }}"
           release_name: calibre
           chart_name: calibre
           # PUID={{ uid }} gives write access on the pod
           # 568 is the default user ID, added to the groups cause why not
+          # The following has been set to disable Truecharts own injection
+          # of manifests for SCALE products I believe
+          # either way I dont need it:
+          # - common.manifests.enabled=false
           set_options: "--set \
             controller.type=statefulset,\
+            common.manifests.enabled=false,\
             common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
             env.PUID=\"{{ uid }}\",\
             env.PGID=\"568\",\


### PR DESCRIPTION
Luckily, TrueCharts was an inital fork of k8s-at-home so the config as I had it works here by default. Only had to change the repo.

NOTE: arm architecture doesnt seem to be supported at the moment