### PR TITLE
fixes grafana not coming up after a restart with loki

### DIFF
--- a/install-charts.yaml
+++ b/install-charts.yaml
@@ -101,9 +101,10 @@
           release_name: loki-stack
           chart_name: loki-stack
           set_options: "--set \
-            test_pod.enable=false,\
-            fluent-bit.enabled=true,\
-            promtail.enabled=false"
+            loki.isDefault=False,\
+            test_pod.enable=False,\
+            fluent-bit.enabled=True,\
+            promtail.enabled=False"
 
       - name: Set config for Grafana to add Loki as a data source
         set_fact:


### PR DESCRIPTION
Issue was caused because of loki.isDefault config which defaults to true, needs to be set to false.
Related issue: https://github.com/prometheus-community/helm-charts/issues/2251