### PR TITLE
Fix chart installs for TC major update

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Use your own server
       - Go to ``Settings > Subtitles`` and make changes if needed
       - Manually add the language profile to all the scanned media after first installation
     - NOTE:
-      - If it doesnt work, manually reinstall this service a few times. It just works, not sure why
+      - If it doesnt work, manually restart the pod few times. It just works, not sure why. If that doesnt work, try reinstalling.
 
   - ##### Setup Ombi
     - One stop shop for Sonarr/Radarr/Lidarr requests

--- a/README.md
+++ b/README.md
@@ -137,6 +137,27 @@ Use your own server
     - Set torrent download/upload limits
       - Recommended to keep 6 active torrents/downloads and 0 uploads. It is under ``Tools > Options > BitTorrent > Torrent Queueing``
 
+  - ##### Setup Calibre
+    - Do base setup
+      - Set folder to be ``/media/data/books`` and select ``Yes`` for it to rebuild the library if asked.
+    - Go to ``Preferences > Sharing over the net``
+      - Check the box for ``Require username and password to access the Content server``
+      - Check the box for ``Run the server automatically when calibre starts``
+      - Click on ``Start server``
+      - Go to the ``User accounts tab`` and create a user
+        - Make a note of the credentials for use in ``Readarr`` setup
+      - Restart the app/pod
+        - You can do so by also pressing `CTRL + R` on the main screen
+
+  - ##### Setup Calibre Web
+    - Default login is ``admin/admin123``
+    - Set folder to be ``/media/data/books``
+    - To enable web reading, click on ``Admin`` (case sensitive) on the top right
+      - Click on the user, default is ``admin``
+      - Enable ``Allow ebook viewer``
+      - Change password to something more secure
+      - Save settings
+
   - ##### Setup Radarr/Sonarr/Readarr/Lidarr
     - Service function
 
@@ -285,27 +306,6 @@ Use your own server
         AutoApproveMovie
         RequestTv
         ```
-
-  - ##### Setup Calibre
-    - Do base setup
-      - Set folder to be ``/media/data/books`` and select ``Yes`` for it to rebuild the library if asked.
-    - Go to ``Preferences > Sharing over the net``
-      - Check the box for ``Require username and password to access the Content server``
-      - Check the box for ``Run the server automatically when calibre starts``
-      - Click on ``Start server``
-      - Go to the ``User accounts tab`` and create a user
-        - Make a note of the credentials for use in ``Readarr`` setup
-      - Restart the app/pod
-        - You can do so by also pressing `CTRL + R` on the main screen
-
-  - ##### Setup Calibre Web
-    - Default login is ``admin/admin123``
-    - Set folder to be ``/media/data/books``
-    - To enable web reading, click on ``Admin`` (case sensitive) on the top right
-      - Click on the user, default is ``admin``
-      - Enable ``Allow ebook viewer``
-      - Change password to something more secure
-      - Save settings
 
   - ##### Setup Minikube for remote access
     - Use the kubeconfig file copied over to the current working directory by exporting it

--- a/install-charts.yaml
+++ b/install-charts.yaml
@@ -500,6 +500,8 @@
           chart_name: calibre
           # PUID={{ uid }} gives write access on the pod
           # 568 is the default user ID, added to the groups cause why not
+          # securityContext.container.seccompProfile.type is required for the
+          # guacamole VNC client to be able to make sys calls (required )
           set_options: "--set \
             {{ helm_common_general }},\
             {{ helm_common_persistence }},\
@@ -507,6 +509,7 @@
             {{ helm_common_resources }},\
             securityContext.container.PUID=\"{{ uid }}\",\
             securityContext.container.PGID=\"568\",\
+            securityContext.container.seccompProfile.type=Unconfined,\
             service.webserver.enabled=true"
 
       - name: Expose calibre service

--- a/install-charts.yaml
+++ b/install-charts.yaml
@@ -13,12 +13,11 @@
     # of manifests for SCALE products I believe either way I dont need it:
     # - common.manifests.enabled=false
     helm_common_general: "\
-      controller.type=statefulset,\
       global.addMetalLBAnnotations=false,\
       global.addTraefikAnnotations=false,\
-      common.dnsConfig.nameservers={8.8.8.8,8.8.4.4},\
-      common.manifests.enabled=false,\
-      common.manifestManager.enabled=false"
+      manifestManager.enabled=false,\
+      workload.main.type=StatefulSet,\
+      podOptions.dnsConfig.nameservers={8.8.8.8,8.8.4.4}"
     
     helm_common_ingress: "\
       ingress.main.enabled=true,\
@@ -36,10 +35,10 @@
       resources.limits.memory={{ charts.resources.limits.memory }}"
 
     helm_common_persistence: "\
-      common.persistence.shared.enabled=false,\
-      common.persistence.shm.enabled=false,\
-      common.persistence.temp.enabled=false,\
-      common.persistence.varlogs.enabled=false,\
+      persistence.shared.enabled=false,\
+      persistence.shm.enabled=false,\
+      persistence.temp.enabled=false,\
+      persistence.varlogs.enabled=false,\
       persistence.config.enabled=true,\
       persistence.config.size=1Gi"
 
@@ -53,9 +52,9 @@
     # backups in /config/Backups
     # runAsUser={{ uid }} gives write access on the pod
     helm_common_security_contexts: "\
-      common.securityContext.readOnlyRootFilesystem=false,\
-      common.podSecurityContext.runAsUser={{ uid }},\
-      common.podSecurityContext.runAsGroup=568"
+      securityContext.container.readOnlyRootFilesystem=false,\
+      securityContext.container.runAsUser={{ uid }},\
+      securityContext.container.runAsGroup=568"
 
   tasks:
     - name: Create namespaces namespace
@@ -156,9 +155,9 @@
           chart_name: jellyfin
           # to allow the pod to be able to use the /dev mount
           # to access /dev/dri/renderD128 for hwa, these options are set to true
-          # - common.podSecurityContext.runAsUser=0
-          # - common.securityContext.privileged=true
-          # - common.securityContext.allowPrivilegeEscalation=true
+          # - securityContext.container.runAsUser=0
+          # - securityContext.container.privileged=true
+          # - securityContext.container.allowPrivilegeEscalation=true
           set_options: "--set \
             {{ helm_common_general }},\
             {{ helm_common_persistence }},\
@@ -166,10 +165,10 @@
             {{ helm_common_persistence_media }},\
             {{ helm_common_resources }},\
             {{ helm_common_ingress }},\
-            common.podSecurityContext.runAsUser=0,\
-            common.securityContext.privileged=true,\
-            common.securityContext.runAsNonRoot=false,\
-            common.securityContext.allowPrivilegeEscalation=true,\
+            securityContext.container.runAsUser=0,\
+            securityContext.container.privileged=true,\
+            securityContext.container.runAsNonRoot=false,\
+            securityContext.container.allowPrivilegeEscalation=true,\
             persistence.cache.enabled=true,\
             persistence.cache.accessMode=ReadWriteOnce,\
             persistence.cache.size=50G,\
@@ -445,9 +444,9 @@
             {{ helm_common_persistence }},\
             {{ helm_common_resources }},\
             {{ helm_common_ingress }},\
-            env.PUID=\"{{ uid }}\",\
-            env.PGID=\"568\",\
-            common.podSecurityContext.fsGroup=568,\
+            securityContext.container.PUID=\"{{ uid }}\",\
+            securityContext.container.PGID=\"568\",\
+            securityContext.pod.fsGroup=568,\
             ingress.main.hosts[0].host='librespeed.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].service.name=librespeed,\
             ingress.main.hosts[0].paths[0].service.port=10016"
@@ -476,9 +475,9 @@
             {{ helm_common_persistence_media }},\
             {{ helm_common_resources }},\
             {{ helm_common_ingress }},\
-            env.PUID=\"{{ uid }}\",\
-            env.PGID=\"568\",\
-            podSecurityContext.fsGroup=568,\
+            securityContext.container.PUID=\"{{ uid }}\",\
+            securityContext.container.PGID=\"568\",\
+            securityContext.pod.fsGroup=568,\
             ingress.main.hosts[0].host='calibre-web.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].service.name=calibre-web,\
             ingress.main.hosts[0].paths[0].service.port=8083"
@@ -508,9 +507,9 @@
             {{ helm_common_persistence }},\
             {{ helm_common_persistence_media }},\
             {{ helm_common_resources }},\
-            env.PUID=\"{{ uid }}\",\
-            env.PGID=\"568\",\
-            podSecurityContext.fsGroup=568,\
+            securityContext.container.PUID=\"{{ uid }}\",\
+            securityContext.container.PGID=\"568\",\
+            securityContext.pod.fsGroup=568,\
             service.webserver.enabled=true"
 
       - name: Expose calibre service

--- a/install-charts.yaml
+++ b/install-charts.yaml
@@ -446,7 +446,6 @@
             {{ helm_common_ingress }},\
             securityContext.container.PUID=\"{{ uid }}\",\
             securityContext.container.PGID=\"568\",\
-            securityContext.pod.fsGroup=568,\
             ingress.main.hosts[0].host='librespeed.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].service.name=librespeed,\
             ingress.main.hosts[0].paths[0].service.port=10016"
@@ -477,7 +476,6 @@
             {{ helm_common_ingress }},\
             securityContext.container.PUID=\"{{ uid }}\",\
             securityContext.container.PGID=\"568\",\
-            securityContext.pod.fsGroup=568,\
             ingress.main.hosts[0].host='calibre-web.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].service.name=calibre-web,\
             ingress.main.hosts[0].paths[0].service.port=8083"
@@ -509,7 +507,6 @@
             {{ helm_common_resources }},\
             securityContext.container.PUID=\"{{ uid }}\",\
             securityContext.container.PGID=\"568\",\
-            securityContext.pod.fsGroup=568,\
             service.webserver.enabled=true"
 
       - name: Expose calibre service

--- a/install-cn-basics.yaml
+++ b/install-cn-basics.yaml
@@ -57,7 +57,7 @@
 
       - name: Download google cloud public signing key
         become: true
-        shell: curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+        shell: curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
 
       - name: Add the Kubernetes apt repository
         become: true


### PR DESCRIPTION
Fix chart installs for TC major update by changing the default configs

Changed the key location used for kubectl install

removed fsgroup from librespeed, calibre and calibre-web as they default to it anyway and most others use it. fsgroup doesnt do anything on hostpath either for minikube

closes #14 