### PR TITLE
Move configs to hostpath

### DIFF
--- a/install-charts.yaml
+++ b/install-charts.yaml
@@ -34,13 +34,16 @@
       resources.limits.cpu={{ charts.resources.limits.cpu }},\
       resources.limits.memory={{ charts.resources.limits.memory }}"
 
+    # persistence.config.hostPathType=DirectoryOrCreate doesnt work
+    # because it creates the dir with root ownership and no write permissions
     helm_common_persistence: "\
       persistence.shared.enabled=false,\
       persistence.shm.enabled=false,\
       persistence.temp.enabled=false,\
       persistence.varlogs.enabled=false,\
       persistence.config.enabled=true,\
-      persistence.config.size=1Gi"
+      persistence.config.type=hostPath,\
+      persistence.config.mountPath=/config"
 
     helm_common_persistence_media: "\
       persistence.media.enabled=true,\
@@ -242,6 +245,12 @@
     - name: Install prowlarr
       when: charts.services.prowlarr.enabled
       block:
+      - name: Create config directory on hostpath for prowlarr
+        file:
+          path: "{{ dir_home }}{{ dir_data_config_suffix }}/prowlarr"
+          state: directory
+          mode: '0755'
+
       - name: Install/Upgrade the prowlarr chart
         include_tasks: tasks-install-chart.yaml
         vars:
@@ -258,6 +267,7 @@
             {{ helm_common_persistence_media }},\
             {{ helm_common_resources }},\
             {{ helm_common_ingress }},\
+            persistence.config.hostPath={{ dir_minikube_mount }}{{ dir_data_config_suffix }}/prowlarr,\
             ingress.main.hosts[0].host='prowlarr.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].service.name=prowlarr,\
             ingress.main.hosts[0].paths[0].service.port=9696"
@@ -273,6 +283,12 @@
     - name: Install radarr
       when: charts.services.radarr.enabled
       block:
+      - name: Create config directory on hostpath for radarr
+        file:
+          path: "{{ dir_home }}{{ dir_data_config_suffix }}/radarr"
+          state: directory
+          mode: '0755'
+
       - name: Install/Upgrade the radarr chart
         include_tasks: tasks-install-chart.yaml
         vars:
@@ -289,6 +305,7 @@
             {{ helm_common_persistence_media }},\
             {{ helm_common_resources }},\
             {{ helm_common_ingress }},\
+            persistence.config.hostPath={{ dir_minikube_mount }}{{ dir_data_config_suffix }}/radarr,\
             ingress.main.hosts[0].host='radarr.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].service.name=radarr,\
             ingress.main.hosts[0].paths[0].service.port=7878"
@@ -303,6 +320,12 @@
     - name: Install sonarr
       when: charts.services.sonarr.enabled
       block:
+      - name: Create config directory on hostpath for sonarr
+        file:
+          path: "{{ dir_home }}{{ dir_data_config_suffix }}/sonarr"
+          state: directory
+          mode: '0755'
+
       - name: Install/Upgrade the sonarr chart
         include_tasks: tasks-install-chart.yaml
         vars:
@@ -319,6 +342,7 @@
             {{ helm_common_persistence_media }},\
             {{ helm_common_resources }},\
             {{ helm_common_ingress }},\
+            persistence.config.hostPath={{ dir_minikube_mount }}{{ dir_data_config_suffix }}/sonarr,\
             ingress.main.hosts[0].host='sonarr.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].service.name=sonarr,\
             ingress.main.hosts[0].paths[0].service.port=8989"
@@ -333,6 +357,12 @@
     - name: Install bazarr
       when: charts.services.bazarr.enabled
       block:
+      - name: Create config directory on hostpath for bazarr
+        file:
+          path: "{{ dir_home }}{{ dir_data_config_suffix }}/bazarr"
+          state: directory
+          mode: '0755'
+
       - name: Install/Upgrade the bazarr chart
         include_tasks: tasks-install-chart.yaml
         vars:
@@ -349,6 +379,7 @@
             {{ helm_common_persistence_media }},\
             {{ helm_common_resources }},\
             {{ helm_common_ingress }},\
+            persistence.config.hostPath={{ dir_minikube_mount }}{{ dir_data_config_suffix }}/bazarr,\
             ingress.main.hosts[0].host='bazarr.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].service.name=bazarr,\
             ingress.main.hosts[0].paths[0].service.port=6767"
@@ -362,6 +393,12 @@
     - name: Install readarr
       when: charts.services.readarr.enabled
       block:
+      - name: Create config directory on hostpath for readarr
+        file:
+          path: "{{ dir_home }}{{ dir_data_config_suffix }}/readarr"
+          state: directory
+          mode: '0755'
+
       - name: Install/Upgrade the readarr chart
         include_tasks: tasks-install-chart.yaml
         vars:
@@ -378,6 +415,7 @@
             {{ helm_common_persistence_media }},\
             {{ helm_common_resources }},\
             {{ helm_common_ingress }},\
+            persistence.config.hostPath={{ dir_minikube_mount }}{{ dir_data_config_suffix }}/readarr,\
             ingress.main.hosts[0].host='readarr.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].service.name=readarr,\
             ingress.main.hosts[0].paths[0].service.port=8787"
@@ -391,6 +429,12 @@
     - name: Install lidarr
       when: charts.services.lidarr.enabled
       block:
+      - name: Create config directory on hostpath for lidarr
+        file:
+          path: "{{ dir_home }}{{ dir_data_config_suffix }}/lidarr"
+          state: directory
+          mode: '0755'
+
       - name: Install/Upgrade the lidarr chart
         include_tasks: tasks-install-chart.yaml
         vars:
@@ -407,6 +451,7 @@
             {{ helm_common_persistence_media }},\
             {{ helm_common_resources }},\
             {{ helm_common_ingress }},\
+            persistence.config.hostPath={{ dir_minikube_mount }}{{ dir_data_config_suffix }}/lidarr,\
             ingress.main.hosts[0].host='lidarr.{{ domain_name }}',\
             ingress.main.hosts[0].paths[0].service.name=lidarr,\
             ingress.main.hosts[0].paths[0].service.port=8686"

--- a/server-basics.yaml
+++ b/server-basics.yaml
@@ -85,6 +85,7 @@
         - "{{ dir_data_books }}"
         - "{{ dir_data_music }}"
         - "{{ dir_data_downloads }}"
+        - "{{ dir_home }}{{ dir_data_config_suffix }}"
 
     - name: Setup the bashrc file and the vimrc file
       block:

--- a/setup.yaml
+++ b/setup.yaml
@@ -27,6 +27,7 @@
         dir_data_books: "/home/{{ ansible_user }}/data/books"
         dir_data_music: "/home/{{ ansible_user }}/data/music"
         dir_data_downloads: "/home/{{ ansible_user }}/data/downloads"
+        dir_data_config_suffix: "/data/app-configs"
 
 - import_playbook: server-basics.yaml
   when:


### PR DESCRIPTION
Configs are now stored on the hostpath instead of the PVCs automatically created. This will allow the backups to persist through a minikube/k8s failure.