### PR TITLE
Update install-and-configure-otbr.yaml

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -134,6 +134,12 @@ otbr:
   # the location at which your radio co-processor (rcp) device is located
   rcp_location: /dev/ttyUSB0
 
+  # baudrate for the rcp device
+  rcp_baudrate: 460800
+
+  # flow control for the rcp device, disable if device does not support it (ztb-1 does)
+  rcp_flow_control: true
+
   # openthread border router network settings
   # provide a different networkkey, extpandid and name to create a
   # new network (all 3)

--- a/install-and-configure-otbr.yaml
+++ b/install-and-configure-otbr.yaml
@@ -47,8 +47,8 @@
           become: true
           shell: |
             echo 'OTBR_WEB_OPTS="-I 0.0.0.0 -p 8080"' > /etc/default/otbr-web
- 
-        - name: "Patch config to use correct Radio Co-Processor (RCP) device from the default and add configs for baudrate and flow control"
+
+        - name: "Patch config to use correct Radio Co-Processor (RCP) device from the default {{ default_rcp_location }}"
           become: true
           shell: |
             # create a rule to have the relevant device always created as /dev/ttyRCP
@@ -61,7 +61,7 @@
             udevadm trigger
 
             # make OTBR use /dev/ttyRCP and increase baudrate and introduce uart-flow-control to work when there is a storm of requests on reboots
-            sed -i -E 's|spinel+hdlc+uart://.*[^"]|spinel+hdlc+uart:///dev/ttyRCP?uart-baudrate={{ otbr.rcp_baudrate }}{{ "\&uart-flow-control" if otbr.rcp_flow_control else "" }}|g' /etc/default/otbr-agent
+            sed -i -E 's|{{ default_rcp_location }}|/dev/ttyRCP?uart-baudrate={{ otbr.rcp_baudrate }}{{ "\&uart-flow-control" if otbr.rcp_flow_control else "" }}|g' /etc/default/otbr-agent
 
         - name: Start OTBR services
           become: true
@@ -171,4 +171,5 @@
 
     vars:
       otbr_repo_dir: "{{ basics.repos_dir }}/otbr"
+      default_rcp_location: "/dev/ttyACM0"
       config_path: "{{ charts.services.configs_dir }}/otbr-agent"

--- a/install-and-configure-otbr.yaml
+++ b/install-and-configure-otbr.yaml
@@ -60,8 +60,8 @@
             udevadm control --reload-rules
             udevadm trigger
 
-            # make OTBR use /dev/ttyRCP
-            sed -i s:{{ default_rcp_location }}:/dev/ttyRCP:g /etc/default/otbr-agent
+            # make OTBR use /dev/ttyRCP and increase baudrate and introduce uart-flow-control to work when there is a storm of requests on reboots
+            sed -i -E 's|{{ default_rcp_location }}|/dev/ttyRCP?uart-baudrate=4608000\&uart-flow-control|g' /etc/default/otbr-agent
 
         - name: Start OTBR services
           become: true

--- a/install-and-configure-otbr.yaml
+++ b/install-and-configure-otbr.yaml
@@ -61,7 +61,7 @@
             udevadm trigger
 
             # make OTBR use /dev/ttyRCP and increase baudrate and introduce uart-flow-control to work when there is a storm of requests on reboots
-            sed -i -E 's|spinel\+hdlc\+uart://[a-zA-Z0-9_/.-]+(\?.*)?|spinel+hdlc+uart:///dev/ttyRCP?uart-baudrate={{ otbr.rcp_baudrate }}{{ "\&uart-flow-control" if otbr.rcp_flow_control else "" }}|g' /etc/default/otbr-agent
+            sed -i -E 's|spinel+hdlc+uart://.*[^"]|spinel+hdlc+uart:///dev/ttyRCP?uart-baudrate={{ otbr.rcp_baudrate }}{{ "\&uart-flow-control" if otbr.rcp_flow_control else "" }}|g' /etc/default/otbr-agent
 
         - name: Start OTBR services
           become: true

--- a/install-and-configure-otbr.yaml
+++ b/install-and-configure-otbr.yaml
@@ -47,8 +47,8 @@
           become: true
           shell: |
             echo 'OTBR_WEB_OPTS="-I 0.0.0.0 -p 8080"' > /etc/default/otbr-web
-
-        - name: "Patch config to use correct Radio Co-Processor (RCP) device from the default {{ default_rcp_location }}"
+ 
+        - name: "Patch config to use correct Radio Co-Processor (RCP) device from the default and add configs for baudrate and flow control"
           become: true
           shell: |
             # create a rule to have the relevant device always created as /dev/ttyRCP
@@ -171,5 +171,4 @@
 
     vars:
       otbr_repo_dir: "{{ basics.repos_dir }}/otbr"
-      default_rcp_location: "/dev/ttyACM0"
       config_path: "{{ charts.services.configs_dir }}/otbr-agent"

--- a/install-and-configure-otbr.yaml
+++ b/install-and-configure-otbr.yaml
@@ -61,7 +61,7 @@
             udevadm trigger
 
             # make OTBR use /dev/ttyRCP and increase baudrate and introduce uart-flow-control to work when there is a storm of requests on reboots
-            sed -i -E 's|{{ default_rcp_location }}|/dev/ttyRCP?uart-baudrate=4608000\&uart-flow-control|g' /etc/default/otbr-agent
+            sed -i -E 's|spinel\+hdlc\+uart://[a-zA-Z0-9_/.-]+(\?.*)?|spinel+hdlc+uart:///dev/ttyRCP?uart-baudrate={{ otbr.rcp_baudrate }}{{ "\&uart-flow-control" if otbr.rcp_flow_control else "" }}|g' /etc/default/otbr-agent
 
         - name: Start OTBR services
           become: true


### PR DESCRIPTION
This change introduces baudrate and uart flow control to make sure that during a reboot, the influx of messages from matter devices does not overwhelm the RCP (causing OTBR agent to enter a crashloop)